### PR TITLE
@ember/application: Expand FrameworkObject

### DIFF
--- a/types/ember__application/index.d.ts
+++ b/types/ember__application/index.d.ts
@@ -130,7 +130,7 @@ export default class Application extends Engine {
 // whenever we add new base classes to the framework. For example, if we
 // introduce a standalone `Service` or `Route` base class which *does not*
 // extend from `EmberObject`, it will need to be added here.
-type FrameworkObject = EmberObject | GlimmerComponent;
+type FrameworkObject = EmberObject | GlimmerComponent<any>;
 
 /**
  * Framework objects in an Ember application (components, services, routes, etc.)

--- a/types/ember__application/test/index.ts
+++ b/types/ember__application/test/index.ts
@@ -3,6 +3,7 @@ import EngineInstance from '@ember/engine/instance';
 import Owner from '@ember/owner';
 import ApplicationInstance from '@ember/application/instance';
 import Service from '@ember/service';
+import GlimmerComponent from '@glimmer/component';
 
 // $ExpectType Owner | undefined
 getOwner({});
@@ -14,6 +15,23 @@ declare class MyService extends Service {
 declare let myService: MyService;
 // $ExpectType Owner
 getOwner(myService);
+
+declare class MyComponent extends GlimmerComponent {}
+declare let myComponent: MyComponent;
+// $ExpectType Owner
+getOwner(myComponent);
+
+declare class MyComponentWithSignature extends GlimmerComponent<{
+    Element: HTMLDivElement;
+    Args: {
+        Named: {
+            foo: string;
+        };
+    };
+}> {}
+declare let myComponentWithSignature: MyComponentWithSignature;
+// $ExpectType Owner
+getOwner(myComponentWithSignature);
 
 // @ts-expect-error
 getOwner();


### PR DESCRIPTION
Expand `FrameworkObject` to allow `GlimmerComponent` use with generics.

Hit the problem when tried to implement getter in Glimmer Component like

```ts

type Signature = {
  Element: HTMLDivElement;
  Args: {
    Named: {
      foo: string;
    };
  };
};

export default class DummyComponent extends Component<Signature> {
  get logger () {
    return getOwner(this).lookup('service:logger') || console;
  }
}
```

Problem as I understand, is that definition `type FrameworkObject = EmberObject | GlimmerComponent;` does not match the component definition with `Signature` provided and TypeScript does not pick overload
```ts
export function getOwner(object: FrameworkObject): Owner;
```
and instead it chooses
```ts
export function getOwner(object: unknown): Owner | undefined;
```

which may return `undefined` which is wrong in context of the Glimmer Component.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tslint.json` [should contain](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#linter-tslintjson) `{ "extends": "@definitelytyped/dtslint/dt.json" }`, and no additional rules.
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.

If removing a declaration:
- [ ] If a package was never on Definitely Typed, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
